### PR TITLE
k8s files used on AWS

### DIFF
--- a/kubernetes-aws/addons/external-dns.yml
+++ b/kubernetes-aws/addons/external-dns.yml
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+      - name: external-dns
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8
+        args:
+        - --source=service
+        - --source=ingress
+        - --domain-filter=taganaka.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
+        - --provider=aws
+        - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
+        - --registry=txt
+        - --txt-owner-id=taganaka-k8s-com

--- a/kubernetes-aws/daf-cacher/daf-cacher-api.yaml
+++ b/kubernetes-aws/daf-cacher/daf-cacher-api.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: daf-cacher-fe-deployment
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: daf-cacher-fe
+        name: daf-cacher-api
+    spec:
+      containers:
+        - name: seeder
+          image: 071817663189.dkr.ecr.us-west-1.amazonaws.com/daf-cacher:latest
+          args: ["seeder"]
+          volumeMounts:
+            - name: confvolume
+              readOnly: true
+              mountPath: /etc/daf-cache/
+          env:
+            - name: DAF_CACHER_CONFIG_FILE
+              value: "/etc/daf-cache/config-docker.properties"
+        - name: api
+          image: 071817663189.dkr.ecr.us-west-1.amazonaws.com/daf-cacher:latest
+          args: ["server"]
+          volumeMounts:
+            - name: confvolume
+              readOnly: true
+              mountPath: /etc/daf-cache/
+          env:
+            - name: DAF_CACHER_CONFIG_FILE
+              value: "/etc/daf-cache/config-docker.properties"
+          ports:
+            - containerPort: 4567
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 4567
+            initialDelaySeconds: 10
+            periodSeconds: 3
+      volumes:
+        - name: confvolume
+          secret:
+            secretName: daf-cacher-config
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:acm:us-west-1:071817663189:certificate/64dde341-5355-4ef8-b930-03828cbe53b2"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+    external-dns.alpha.kubernetes.io/hostname: daf-cacher.taganaka.com.
+  name: daf-cacher-api
+  labels:
+    app: daf-cacher-fe-service
+spec:
+  selector:
+    app: daf-cacher-fe
+  type: LoadBalancer
+  ports:
+    - name: "https"
+      port: 443
+      targetPort: 4567
+      protocol: "TCP"

--- a/kubernetes-aws/daf-cacher/daf-cacher-worker.yaml
+++ b/kubernetes-aws/daf-cacher/daf-cacher-worker.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: daf-cacher-worker-deployment
+spec:
+  replicas: 6
+  template:
+    metadata:
+      labels:
+        app: daf-cacher-worker
+        name: daf-cacher-worker
+    spec:
+      containers:
+        - name: worker
+          image: 071817663189.dkr.ecr.us-west-1.amazonaws.com/daf-cacher:latest
+          args: ["worker"]
+          volumeMounts:
+            - name: confvolume
+              readOnly: true
+              mountPath: /etc/daf-cache/
+          env:
+            - name: DAF_CACHER_CONFIG_FILE
+              value: "/etc/daf-cache/config-docker.properties"
+      volumes:
+        - name: confvolume
+          secret:
+            secretName: daf-cacher-config

--- a/kubernetes-aws/daf-cacher/redis.yaml
+++ b/kubernetes-aws/daf-cacher/redis.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: redis-deployment
+spec:
+  selector:
+    matchLabels:
+      app: redis
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:4-alpine
+        ports:
+          - containerPort: 6379
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  ports:
+  - name: redis
+    port: 6379
+    targetPort: 6379
+    protocol: TCP
+  selector:
+    app: redis
+
+

--- a/kubernetes-aws/daf-cacher/selenium.yaml
+++ b/kubernetes-aws/daf-cacher/selenium.yaml
@@ -64,4 +64,4 @@ spec:
     targetPort: 5900
     protocol: TCP
   selector:
-    app: daf-metabase-cacher-be
+    app: daf-cacher-selenium

--- a/kubernetes-aws/daf-cacher/selenium.yaml
+++ b/kubernetes-aws/daf-cacher/selenium.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: daf-cacher-selenium-deployment
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: daf-cacher-selenium
+        name: daf-cacher-selenium
+    spec:
+      containers:
+        - name: selenium-node-chrome
+          image: selenium/node-chrome:3.7.1-beryllium
+          ports:
+            - containerPort: 5900
+          env:
+            - name: HUB_PORT_4444_TCP_ADDR
+              value: "localhost"
+            - name: HUB_PORT_4444_TCP_PORT
+              value: "4444"
+            - name: NODE_MAX_INSTANCES
+              value: "60"
+            - name: NODE_MAX_SESSION
+              value: "60"
+            - name: JAVA_OPTS
+              value: -Dselenium.LOGGER.level=WARNING
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
+        - name: selenium
+          image: selenium/hub:latest
+          ports:
+            - containerPort: 4444
+          env:
+            - name: GRID_MAX_SESSION
+              value: "200"
+            - name: GRID_BROWSER_TIMEOUT
+              value: "100000"
+            - name: GRID_TIMEOUT
+              value: "90000"
+            - name: GRID_NEW_SESSION_WAIT_TIMEOUT
+              value: "300000"
+            - name: JAVA_OPTS
+              value: -Dselenium.LOGGER.level=WARNING
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: selenium
+spec:
+  ports:
+  - name: selenium
+    port: 4444
+    targetPort: 4444
+    protocol: TCP
+  - name: chrome
+    port: 5900
+    targetPort: 5900
+    protocol: TCP
+  selector:
+    app: daf-metabase-cacher-be


### PR DESCRIPTION
@giux78 Here is my collection of kubernetes files I'm actually using with success on AWS

```
00:32 $ kubectl version
Client Version: version.Info{Major:"1", Minor:"8", GitVersion:"v1.8.4", GitCommit:"9befc2b8928a9426501d3bf62f72849d5cbcd5a3", GitTreeState:"clean", BuildDate:"2017-11-20T19:11:02Z", GoVersion:"go1.9.2", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"7", GitVersion:"v1.7.10", GitCommit:"bebdeb749f1fa3da9e1312c4b08e439c404b3136", GitTreeState:"clean", BuildDate:"2017-11-03T16:31:49Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
```

There are some AWS-specific boilerplate such as external-dns add-on that can be safely ignored.

The configuration file is shipped as kubernetes secret file. So it should be created in advance with something like this:

```
kubectl create secret generic daf-cacher-config --from-file=secret-config-docker.properties
``` 

Please make use to use the latest code available on master.

A new health status endpoint has been added 
```
/status
```

so that a k8s liveness probe can be use to monitor the app status:

```yaml
livenessProbe:
  httpGet:
    path: /status
    port: 4567
    initialDelaySeconds: 10
    periodSeconds: 3
```

Let me know how it goes.

Cheers