### PR TITLE
No more memory leak

### DIFF
--- a/push-to-aws.sh
+++ b/push-to-aws.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker tag italia/daf-metabase-cacher:latest 071817663189.dkr.ecr.us-west-1.amazonaws.com/daf-cacher:latest
+docker push 071817663189.dkr.ecr.us-west-1.amazonaws.com/daf-cacher:latest

--- a/src/main/java/com/github/italia/daf/CacheWorker.java
+++ b/src/main/java/com/github/italia/daf/CacheWorker.java
@@ -32,6 +32,8 @@ public class CacheWorker {
     private static final String REDIS_Q = "daf-cacher:jobs";
     private static final String REDIS_BPQ = "daf-cacher:jobsbq";
 
+    private static final int REQUEST_RESET_AT = 10;
+
     private static WebDriver getWebDriver(final Properties properties, int timeout) throws MalformedURLException {
         WebDriver webDriver;
         while (true) {
@@ -63,20 +65,7 @@ public class CacheWorker {
 
         final Properties properties = new Configuration(args[0]).load();
         int timeout = 30;
-        WebDriver webDriver = getWebDriver(properties, timeout);
-
-
-        final WebDriver finalWebDriver = webDriver;
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            try {
-                if (finalWebDriver != null) {
-                    finalWebDriver.close();
-                    finalWebDriver.quit();
-                }
-            } catch (Exception ex) {
-                // ignored
-            }
-        }));
+        int maxRequest = REQUEST_RESET_AT;
 
         final Page metabasePageHandler = new MetabaseSniperPageImpl(properties);
         final Page supersetPageHandler = new SupersetSniperPageImpl
@@ -95,6 +84,7 @@ public class CacheWorker {
 
 
         try (final Jedis jedis = new Jedis(new URI(properties.getProperty("caching.redis_host")))) {
+            WebDriver webDriver = getWebDriver(properties, timeout);
             final Gson gson = new GsonBuilder().create();
             final List<Geometry> sizes = new ArrayList<>();
             Arrays
@@ -104,8 +94,11 @@ public class CacheWorker {
             do {
                 final String embedPayload = jedis.brpoplpush(REDIS_Q, REDIS_BPQ, 10);
 
-                if (embedPayload == null)
+                if (embedPayload == null) {
+                    maxRequest = 0;
                     continue;
+
+                }
 
                 if (embedPayload.equals("EXIT")) {
                     LOGGER.log(Level.INFO, () -> "Magic word received ... exiting from the main loop");
@@ -125,7 +118,24 @@ public class CacheWorker {
                     continue;
                 }
 
+                if (maxRequest == 0) {
+                    LOGGER.log(Level.INFO, "Max number of request reached. Refreshing WebDriver");
+                    try {
+                        if (webDriver != null) {
+                            webDriver.close();
+                            webDriver.quit();
+                        }
+                        maxRequest = REQUEST_RESET_AT;
+                        ((SupersetSniperPageImpl) supersetPageHandler).reset();
+                        webDriver = getWebDriver(properties, timeout);
+                    } catch (Exception e) {
+                        LOGGER.log(Level.SEVERE, "An error here", e);
+                    }
+                }
+
+
                 try {
+                    maxRequest--;
                     ScreenShotService service = new ScreenShotService.Builder()
                             .id(embeddableData.getIdentifier())
                             .jedis(jedis)
@@ -139,9 +149,9 @@ public class CacheWorker {
 
                     service.perform();
                 } catch (java.util.concurrent.TimeoutException tex) {
-                    LOGGER.log(Level.SEVERE, "Origin " + embeddableData.getOrigin() + " timeout ex");
-                    LOGGER.log(Level.SEVERE, "WebDriver instance might be tainted. Refresh it");
-                    webDriver = getWebDriver(properties, timeout);
+                    LOGGER.log(Level.SEVERE, "Origin " + embeddableData.getOrigin() + " timeout ex", tex);
+                    LOGGER.log(Level.SEVERE, "WebDriver instance might be tainted. Refreshing it at the next iteration");
+                    maxRequest = 0;
                     continue;
                 }
 

--- a/src/main/java/com/github/italia/daf/CacheWorker.java
+++ b/src/main/java/com/github/italia/daf/CacheWorker.java
@@ -125,12 +125,14 @@ public class CacheWorker {
                             webDriver.close();
                             webDriver.quit();
                         }
+                    } catch (Exception e) {
+                        // ignored
+                    } finally {
                         maxRequest = REQUEST_RESET_AT;
                         ((SupersetSniperPageImpl) supersetPageHandler).reset();
                         webDriver = getWebDriver(properties, timeout);
-                    } catch (Exception e) {
-                        LOGGER.log(Level.SEVERE, "An error here", e);
                     }
+
                 }
 
 

--- a/src/main/java/com/github/italia/daf/selenium/Browser.java
+++ b/src/main/java/com/github/italia/daf/selenium/Browser.java
@@ -43,9 +43,11 @@ public class Browser {
 
         public Builder chrome() {
             this.browserCaps = DesiredCapabilities.chrome();
+
             ChromeOptions options = new ChromeOptions();
             options.addArguments("'--start-maximized", "--window-size=1360,1020");
             this.browserCaps.setCapability(ChromeOptions.CAPABILITY, options);
+            this.browserCaps.setCapability("enableVNC", true);
 
             return this;
         }

--- a/src/main/java/com/github/italia/daf/sniper/PageSniper.java
+++ b/src/main/java/com/github/italia/daf/sniper/PageSniper.java
@@ -1,16 +1,20 @@
 package com.github.italia.daf.sniper;
 
+import com.github.italia.daf.utils.LoggerFactory;
 import org.openqa.selenium.WebDriver;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class PageSniper {
     private static final String ERROR_MSG = "Unable to save the viewport buffer";
     private WebDriver driver;
     private int timeout;
     private Page pageHandler;
+    private static final Logger LOGGER = LoggerFactory.getLogger(PageSniper.class.getName());
 
     public PageSniper(WebDriver driver, int timeOutInSecond) {
         this.driver = driver;
@@ -38,6 +42,7 @@ public class PageSniper {
                 throw new IOException(ERROR_MSG);
             return buffer;
         } catch (InterruptedException | TimeoutException | ExecutionException e) {
+            LOGGER.log(Level.SEVERE, "Future execution exception", e);
             future.cancel(true);
             throw new TimeoutException("Page load timeout: " + url);
         } finally {

--- a/src/main/java/com/github/italia/daf/superset/SupersetSniperPageImpl.java
+++ b/src/main/java/com/github/italia/daf/superset/SupersetSniperPageImpl.java
@@ -47,8 +47,14 @@ public class SupersetSniperPageImpl implements Page {
         webDriver.findElement(By.id("username")).sendKeys(credential.getUsername());
         webDriver.findElement(By.id("password")).sendKeys(credential.getPassword());
         webDriver.findElement(By.id("password")).submit();
+
+        webDriver.findElement(By.id("dash_table"));
         loggedIn = true;
 
+    }
+
+    public void reset() {
+        this.loggedIn = false;
     }
 
     public static class Builder {


### PR DESCRIPTION
@giux78 

This is a first set of cumulative fixes to help in reducing the overall memory consumed by selenium's task.

Second step is to replace seleniumHQ images with [selenoid](https://github.com/aerokube/selenoid), a drop-in-ish replacement for selenium grid

TL;DR

SeleniumHQ images are meant for CI testing and short-living browser session.
Long running sessions are prone to memory leak and after hours they could trash a VM 

Selenoid, to the other hand, has a better memory footprint and a recycle strategy to kill Chrome container automatically when a requested.

It's running now on my cluster and so far so good.

I'll update k8s files soon 

Cheers 